### PR TITLE
Fix error in `Gem::Version.create`

### DIFF
--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -1,3 +1,11 @@
 def enabled_rust_yjit?
-  node.dig(:ruby, :version) && Gem::Version.create(node[:ruby][:version]) >= Gem::Version.create("3.2.0-dev") && node[:ruby][:enabled_yjit]
+  ruby_version = node.dig(:ruby, :version)
+  return false unless ruby_version
+
+  enabled_yjit = node.dig(:ruby, :enabled_yjit)
+  return false unless enabled_yjit
+
+  return true if ruby_version == "ruby-dev"
+
+  Gem::Version.create(ruby_version) >= Gem::Version.create("3.2.0-dev")
 end


### PR DESCRIPTION
```
/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/version.rb:223:in `initialize': Malformed version number string ruby-dev (ArgumentError)

      raise ArgumentError, "Malformed version number string #{version}"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/version.rb:206:in `new'
	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/version.rb:206:in `new'
	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/version.rb:195:in `create'
	from /home/runner/work/isucon-itamae/isucon-itamae/lib/helper.rb:2:in `enabled_rust_yjit?'
	from /home/runner/work/isucon-itamae/isucon-itamae/cookbooks/ruby/default.rb:71:in `block in call'
```